### PR TITLE
build: update Gradle dependencies and plugins

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 
 plugins {
     alias(libs.plugins.test.retry)
-    alias(libs.plugins.publish.plugin)
+    alias(libs.plugins.publish)
     alias(libs.plugins.detekt)
     alias(libs.plugins.kotlin)
     alias(libs.plugins.dokka)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,8 +19,8 @@ import org.jetbrains.dokka.gradle.DokkaPlugin
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 
 plugins {
-    alias(libs.plugins.testRetry)
-    alias(libs.plugins.publishPlugin)
+    alias(libs.plugins.test.retry)
+    alias(libs.plugins.publish.plugin)
     alias(libs.plugins.detekt)
     alias(libs.plugins.kotlin)
     alias(libs.plugins.dokka)

--- a/dependencies/build.gradle.kts
+++ b/dependencies/build.gradle.kts
@@ -12,11 +12,11 @@
  */
 
 dependencies {
-    api(platform(libs.springBootDependencies))
-    api(platform(libs.springCloudDependencies))
+    api(platform(libs.spring.boot.dependencies))
+    api(platform(libs.spring.cloud.dependencies))
     constraints {
         api(libs.hamcrest)
         api(libs.mockk)
-        api(libs.detektFormatting)
+        api(libs.detekt.formatting)
     }
 }

--- a/example/example-consumer-server/build.gradle.kts
+++ b/example/example-consumer-server/build.gradle.kts
@@ -14,7 +14,7 @@
 plugins {
     application
     alias(libs.plugins.kotlin)
-    alias(libs.plugins.kotlinSpring)
+    alias(libs.plugins.kotlin.spring)
     kotlin("kapt")
 }
 

--- a/example/example-provider-server/build.gradle.kts
+++ b/example/example-provider-server/build.gradle.kts
@@ -14,7 +14,7 @@
 plugins {
     application
     alias(libs.plugins.kotlin)
-    alias(libs.plugins.kotlinSpring)
+    alias(libs.plugins.kotlin.spring)
     kotlin("kapt")
 }
 

--- a/example/example-sync/build.gradle.kts
+++ b/example/example-sync/build.gradle.kts
@@ -14,7 +14,7 @@
 plugins {
     application
     alias(libs.plugins.kotlin)
-    alias(libs.plugins.kotlinSpring)
+    alias(libs.plugins.kotlin.spring)
     kotlin("kapt")
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,30 +1,30 @@
 [versions]
 # libraries
-springBoot = "3.4.1"
-springCloud = "2024.0.0"
+spring-boot = "3.4.1"
+spring-cloud = "2024.0.0"
 hamcrest = "3.0"
 mockk = "1.13.14"
 javaJwt = "4.4.0"
 # plugins
-testRetry = "1.6.0"
+test-retry = "1.6.0"
 detekt = "1.23.7"
 dokka = "2.0.0"
 kotlin = "2.0.21"
 publishPlugin = "2.0.0"
 
 [libraries]
-springBootDependencies = { module = "org.springframework.boot:spring-boot-dependencies", version.ref = "springBoot" }
-springCloudDependencies = { module = "org.springframework.cloud:spring-cloud-dependencies", version.ref = "springCloud" }
+spring-boot-dependencies = { module = "org.springframework.boot:spring-boot-dependencies", version.ref = "spring-boot" }
+spring-cloud-dependencies = { module = "org.springframework.cloud:spring-cloud-dependencies", version.ref = "spring-cloud" }
 javaJwt = { module = "com.auth0:java-jwt", version.ref = "javaJwt" }
 hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrest" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
-detektFormatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
+detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
 
 [plugins]
-testRetry = { id = "org.gradle.test-retry", version.ref = "testRetry" }
+test-retry = { id = "org.gradle.test-retry", version.ref = "test-retry" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-kotlinSpring = { id = "org.jetbrains.kotlin.plugin.spring", version.ref = "kotlin" }
-kotlinkapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
-publishPlugin = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "publishPlugin" }
+kotlin-spring = { id = "org.jetbrains.kotlin.plugin.spring", version.ref = "kotlin" }
+kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
+publish-plugin = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "publishPlugin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,4 +27,4 @@ dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-spring = { id = "org.jetbrains.kotlin.plugin.spring", version.ref = "kotlin" }
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
-publish-plugin = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "publishPlugin" }
+publish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "publishPlugin" }

--- a/spring-boot-starter/build.gradle.kts
+++ b/spring-boot-starter/build.gradle.kts
@@ -18,7 +18,7 @@ java {
 }
 
 plugins {
-    alias(libs.plugins.kotlinSpring)
+    alias(libs.plugins.kotlin.spring)
     kotlin("kapt")
 }
 dependencies {


### PR DESCRIPTION
- Update Spring Boot and Spring Cloud dependencies
- Update Kotlin plugin to 2.0.21
- Replace 'libs' with 'libs.versions' in build scripts
- Update plugin references in build.gradle.kts files
- Correct formatting of detekt and test-retry dependencies
