### PR TITLE
build: use project name instead of archives name in manifest

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,7 +50,7 @@ allprojects {
     }
     tasks.withType<Jar> {
         manifest {
-            attributes["Implementation-Title"] = project.name
+            attributes["Implementation-Title"] = project.getArchivesName()
             attributes["Implementation-Version"] = project.version
         }
         duplicatesStrategy = DuplicatesStrategy.EXCLUDE


### PR DESCRIPTION
- Change Implementation-Title attribute from project.name to project.getArchivesName()
- This modification ensures consistency in how the project title is displayed in the manifest