### PR TITLE
build(gradle): adjust compiler arguments for improved reflection support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,7 +89,11 @@ configure(libraryProjects) {
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
         compilerOptions {
             freeCompilerArgs = listOf("-Xjsr305=strict", "-Xjvm-default=all-compatibility")
+            javaParameters = true
         }
+    }
+    tasks.withType<JavaCompile> {
+        options.compilerArgs.addAll(listOf("-parameters"))
     }
     apply<TestRetryPlugin>()
     tasks.withType<Test> {
@@ -106,9 +110,6 @@ configure(libraryProjects) {
             }
             failOnPassedAfterRetry = true
         }
-    }
-    tasks.withType<JavaCompile> {
-        options.compilerArgs.addAll(listOf("-parameters"))
     }
     dependencies {
         api(platform(dependenciesProject))


### PR DESCRIPTION
- Add `javaParameters = true` to Kotlin compiler options
- Move `-parameters` argument to JavaCompile task
- Remove redundant `-parameters` argument from its original position