### PR TITLE
build(spring): update java-jwt dependency and adjust naming

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ spring-boot = "3.4.3"
 spring-cloud = "2024.0.1"
 hamcrest = "3.0"
 mockk = "1.13.17"
-javaJwt = "4.5.0"
+java-jwt = "4.5.0"
 # plugins
 test-retry = "1.6.2"
 detekt = "1.23.8"
@@ -15,7 +15,7 @@ publishPlugin = "2.0.0"
 [libraries]
 spring-boot-dependencies = { module = "org.springframework.boot:spring-boot-dependencies", version.ref = "spring-boot" }
 spring-cloud-dependencies = { module = "org.springframework.cloud:spring-cloud-dependencies", version.ref = "spring-cloud" }
-javaJwt = { module = "com.auth0:java-jwt", version.ref = "javaJwt" }
+java-jwt = { module = "com.auth0:java-jwt", version.ref = "java-jwt" }
 hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrest" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }

--- a/spring/build.gradle.kts
+++ b/spring/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
     api("org.springframework:spring-web")
     "reactiveSupportImplementation"("org.springframework:spring-webflux")
     "lbSupportImplementation"("org.springframework.cloud:spring-cloud-commons")
-    "jwtSupportImplementation"(libs.javaJwt)
+    "jwtSupportImplementation"(libs.java.jwt)
     testImplementation("io.projectreactor:reactor-test")
     testImplementation("io.projectreactor.kotlin:reactor-kotlin-extensions")
     testImplementation(project(":example-provider-api"))


### PR DESCRIPTION
- Update javaJwt version to 4.5.0 in gradle/libs.versions.toml
- Rename javaJwt to java-jwt for consistency with library name
- Update corresponding build.gradle.kts file to use new java-jwt name
