### PR TITLE
build(deps): move kotlin-logging-jvm to spring module

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -115,7 +115,6 @@ configure(libraryProjects) {
         api(platform(dependenciesProject))
         detektPlugins(platform(dependenciesProject))
         implementation("org.slf4j:slf4j-api")
-        implementation("io.github.oshai:kotlin-logging-jvm")
         testImplementation("ch.qos.logback:logback-classic")
         testImplementation("org.junit.jupiter:junit-jupiter-api")
         testImplementation("org.junit.jupiter:junit-jupiter-params")

--- a/spring/build.gradle.kts
+++ b/spring/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
     api(project(":api"))
     api("org.springframework:spring-context")
     api("org.springframework:spring-web")
+    implementation("io.github.oshai:kotlin-logging-jvm")
     "reactiveSupportImplementation"("org.springframework:spring-webflux")
     "lbSupportImplementation"("org.springframework.cloud:spring-cloud-commons")
     "jwtSupportImplementation"(libs.java.jwt)


### PR DESCRIPTION
- Remove io.github.oshai:kotlin-logging-jvm from the common build.gradle.kts
- Add io.github.oshai:kotlin-logging-jvm to the spring module's build.gradle.kts