### PR TITLE
feat(spring-boot-starter): add support for beans CoApiDefinition

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -3,4 +3,26 @@
   <component name="CompilerConfiguration">
     <bytecodeTargetLevel target="17" />
   </component>
+  <component name="JavacSettings">
+    <option name="ADDITIONAL_OPTIONS_OVERRIDE">
+      <module name="CoApi.api" options="-parameters" />
+      <module name="CoApi.api.main" options="-parameters" />
+      <module name="CoApi.api.test" options="-parameters" />
+      <module name="CoApi.example-consumer-server" options="-parameters -proc:none" />
+      <module name="CoApi.example-consumer-server.main" options="-parameters -proc:none" />
+      <module name="CoApi.example-consumer-server.test" options="-parameters -proc:none" />
+      <module name="CoApi.example-provider-server" options="-parameters -proc:none" />
+      <module name="CoApi.example-provider-server.main" options="-parameters -proc:none" />
+      <module name="CoApi.example-provider-server.test" options="-parameters -proc:none" />
+      <module name="CoApi.example-sync" options="-parameters -proc:none" />
+      <module name="CoApi.example-sync.main" options="-parameters -proc:none" />
+      <module name="CoApi.example-sync.test" options="-parameters -proc:none" />
+      <module name="CoApi.spring" options="-parameters" />
+      <module name="CoApi.spring-boot-starter" options="-parameters -proc:none" />
+      <module name="CoApi.spring-boot-starter.main" options="-parameters -proc:none" />
+      <module name="CoApi.spring-boot-starter.test" options="-parameters -proc:none" />
+      <module name="CoApi.spring.main" options="-parameters" />
+      <module name="CoApi.spring.test" options="-parameters" />
+    </option>
+  </component>
 </project>

--- a/spring-boot-starter/src/main/kotlin/me/ahoo/coapi/spring/boot/starter/AutoCoApiRegistrar.kt
+++ b/spring-boot-starter/src/main/kotlin/me/ahoo/coapi/spring/boot/starter/AutoCoApiRegistrar.kt
@@ -49,12 +49,13 @@ class AutoCoApiRegistrar : AbstractCoApiRegistrar() {
         if (coApiBasePackages.isNotEmpty()) {
             return coApiBasePackages
         }
-        return AutoConfigurationPackages.get(appContext) + coApiBasePackages
+        return AutoConfigurationPackages.get(appContext)
     }
 
     override fun getCoApiDefinitions(importingClassMetadata: AnnotationMetadata): Set<CoApiDefinition> {
+        val beanProvider = appContext.getBeanProvider(CoApiDefinition::class.java).toList()
         val scanBasePackages = getScanBasePackages()
-        return scanBasePackages.toApiClientDefinitions()
+        return scanBasePackages.toApiClientDefinitions() + beanProvider
     }
 
     private fun List<String>.toApiClientDefinitions(): Set<CoApiDefinition> {


### PR DESCRIPTION
- Add bean provider for CoApiDefinition to get definitions from beans
- Update getCoApiDefinitions to include both scanned packages and beans
