### PR TITLE
refactor(spring-boot-starter): use Set instead of List for base packages

### DIFF
--- a/spring-boot-starter/src/main/kotlin/me/ahoo/coapi/spring/boot/starter/AutoCoApiRegistrar.kt
+++ b/spring-boot-starter/src/main/kotlin/me/ahoo/coapi/spring/boot/starter/AutoCoApiRegistrar.kt
@@ -46,7 +46,7 @@ class AutoCoApiRegistrar : AbstractCoApiRegistrar() {
 
     private fun getScanBasePackages(): List<String> {
         val coApiBasePackages = getCoApiBasePackages()
-        if (coApiBasePackages.isNotEmpty() && !AutoConfigurationPackages.has(appContext)) {
+        if (AutoConfigurationPackages.has(appContext).not()) {
             return coApiBasePackages
         }
         return AutoConfigurationPackages.get(appContext) + coApiBasePackages

--- a/spring-boot-starter/src/main/kotlin/me/ahoo/coapi/spring/boot/starter/AutoCoApiRegistrar.kt
+++ b/spring-boot-starter/src/main/kotlin/me/ahoo/coapi/spring/boot/starter/AutoCoApiRegistrar.kt
@@ -46,10 +46,10 @@ class AutoCoApiRegistrar : AbstractCoApiRegistrar() {
 
     private fun getScanBasePackages(): List<String> {
         val coApiBasePackages = getCoApiBasePackages()
-        if (coApiBasePackages.isNotEmpty()) {
+        if (coApiBasePackages.isNotEmpty() && !AutoConfigurationPackages.has(appContext)) {
             return coApiBasePackages
         }
-        return AutoConfigurationPackages.get(appContext)
+        return AutoConfigurationPackages.get(appContext) + coApiBasePackages
     }
 
     override fun getCoApiDefinitions(importingClassMetadata: AnnotationMetadata): Set<CoApiDefinition> {

--- a/spring-boot-starter/src/main/kotlin/me/ahoo/coapi/spring/boot/starter/AutoCoApiRegistrar.kt
+++ b/spring-boot-starter/src/main/kotlin/me/ahoo/coapi/spring/boot/starter/AutoCoApiRegistrar.kt
@@ -26,13 +26,13 @@ import org.springframework.core.type.filter.AnnotationTypeFilter
 
 class AutoCoApiRegistrar : AbstractCoApiRegistrar() {
 
-    private fun getCoApiBasePackages(): List<String> {
+    private fun getCoApiBasePackages(): Set<String> {
         val basePackages = env.getProperty(CoApiProperties.COAPI_BASE_PACKAGES)
         if (basePackages?.isNotBlank() == true) {
-            return basePackages.split(",").distinct().toList()
+            return basePackages.split(",").toSet()
         }
         var currentIndex = 0
-        buildList {
+        buildSet {
             while (true) {
                 val basePackage = env.getProperty("${CoApiProperties.COAPI_BASE_PACKAGES}[$currentIndex]")
                 if (basePackage.isNullOrBlank()) {
@@ -44,12 +44,12 @@ class AutoCoApiRegistrar : AbstractCoApiRegistrar() {
         }
     }
 
-    private fun getScanBasePackages(): List<String> {
+    private fun getScanBasePackages(): Set<String> {
         val coApiBasePackages = getCoApiBasePackages()
         if (AutoConfigurationPackages.has(appContext).not()) {
             return coApiBasePackages
         }
-        return AutoConfigurationPackages.get(appContext) + coApiBasePackages
+        return AutoConfigurationPackages.get(appContext).toSet() + coApiBasePackages
     }
 
     override fun getCoApiDefinitions(importingClassMetadata: AnnotationMetadata): Set<CoApiDefinition> {
@@ -58,7 +58,7 @@ class AutoCoApiRegistrar : AbstractCoApiRegistrar() {
         return scanBasePackages.toApiClientDefinitions() + beanProvider
     }
 
-    private fun List<String>.toApiClientDefinitions(): Set<CoApiDefinition> {
+    private fun Set<String>.toApiClientDefinitions(): Set<CoApiDefinition> {
         val scanner = ApiClientScanner(false, env)
         return flatMap { basePackage ->
             scanner.findCandidateComponents(basePackage)

--- a/spring-boot-starter/src/test/kotlin/me/ahoo/coapi/spring/boot/starter/CoApiAutoConfigurationTest.kt
+++ b/spring-boot-starter/src/test/kotlin/me/ahoo/coapi/spring/boot/starter/CoApiAutoConfigurationTest.kt
@@ -28,6 +28,7 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.notNullValue
 import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurationPackage
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.autoconfigure.web.reactive.function.client.WebClientAutoConfiguration
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
@@ -158,6 +159,9 @@ class CoApiAutoConfigurationTest {
     }
 }
 
+@AutoConfigurationPackage(
+    basePackageClasses = [GitHubApiClient::class]
+)
 @SpringBootApplication
 @EnableCoApi(
     clients = [


### PR DESCRIPTION
- Change getCoApiBasePackages() to return Set<String> instead of List<String>
- Update getScanBasePackages() to use Set<String> instead of List<String>
- Modify toApiClientDefinitions() to work with Set<String> instead of List<String>
- These changes improve performance by using a set to store unique base packages