### PR TITLE
ci: remove paths-ignore for push events

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,9 +1,5 @@
 name: Codecov
 on:
-  push:
-    paths-ignore:
-      - 'documentation/**'
-      - 'example/**'
   pull_request:
     paths-ignore:
       - 'documentation/**'

--- a/.github/workflows/example-test.yml
+++ b/.github/workflows/example-test.yml
@@ -13,9 +13,6 @@
 
 name: Example Test
 on:
-  push:
-    paths-ignore:
-      - 'documentation/**'
   pull_request:
     paths-ignore:
       - 'documentation/**'

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -13,10 +13,6 @@
 
 name: Integration Test
 on:
-  push:
-    paths-ignore:
-      - 'documentation/**'
-      - 'example/**'
   pull_request:
     paths-ignore:
       - 'documentation/**'


### PR DESCRIPTION
- Remove paths-ignore configuration for push events in Codecov, Example Test, and Integration Test workflows
- This change ensures that all code changes are properly tested and analyzed, regardless of their location in the repository
