### PR TITLE
refactor(spring): improve load balancing determination logic

### DIFF
--- a/spring/src/main/kotlin/me/ahoo/coapi/spring/CoApiDefinition.kt
+++ b/spring/src/main/kotlin/me/ahoo/coapi/spring/CoApiDefinition.kt
@@ -55,7 +55,7 @@ data class CoApiDefinition(
         /**
          * Prefix for load balanced protocol.
          */
-        private const val LB_PROTOCOL_PREFIX = "lb://"
+        const val LB_PROTOCOL_PREFIX = "lb://"
 
         /**
          * Prefix for HTTP protocol.

--- a/spring/src/main/kotlin/me/ahoo/coapi/spring/client/IHttpClientFactoryBean.kt
+++ b/spring/src/main/kotlin/me/ahoo/coapi/spring/client/IHttpClientFactoryBean.kt
@@ -14,6 +14,7 @@
 package me.ahoo.coapi.spring.client
 
 import me.ahoo.coapi.spring.CoApiDefinition
+import me.ahoo.coapi.spring.CoApiDefinition.Companion.LB_PROTOCOL_PREFIX
 import org.springframework.context.ApplicationContext
 
 interface IHttpClientFactoryBean {
@@ -28,10 +29,6 @@ interface IHttpClientFactoryBean {
     }
 
     fun loadBalanced(): Boolean {
-        val clientProperties = appContext.getBean(ClientProperties::class.java)
-        if (clientProperties.getBaseUri(definition.name).isNotBlank()) {
-            return false
-        }
-        return definition.loadBalanced
+        return getBaseUrl().startsWith(LB_PROTOCOL_PREFIX) || definition.loadBalanced
     }
 }


### PR DESCRIPTION
- Remove unused private modifier from LB_PROTOCOL_PREFIX
- Simplify loadBalanced() function in IHttpClientFactoryBean
- Use startsWith() to check for load balancing prefix
- Remove unnecessary bean retrieval and condition check