### PR TITLE
build: upgrade to JUnit 5.13.0 and related dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -113,6 +113,7 @@ configure(libraryProjects) {
     }
     dependencies {
         api(platform(dependenciesProject))
+        testImplementation(platform(rootProject.libs.junit.bom))
         detektPlugins(platform(dependenciesProject))
         implementation("org.slf4j:slf4j-api")
         testImplementation("ch.qos.logback:logback-classic")
@@ -123,6 +124,7 @@ configure(libraryProjects) {
             exclude(group = "org.slf4j", module = "slf4j-api")
         }
         testImplementation("io.micrometer:micrometer-core")
+        testRuntimeOnly("org.junit.platform:junit-platform-launcher")
         testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
         detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting")
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@
 spring-boot = "3.4.5"
 spring-cloud = "2024.0.1"
 kotlin-logging = "7.0.7"
+junit = "5.13.0"
 fluent-assert = "0.1.2"
 mockk = "1.14.2"
 java-jwt = "4.5.0"
@@ -18,6 +19,7 @@ spring-boot-dependencies = { module = "org.springframework.boot:spring-boot-depe
 spring-cloud-dependencies = { module = "org.springframework.cloud:spring-cloud-dependencies", version.ref = "spring-cloud" }
 kotlin-logging = { module = "io.github.oshai:kotlin-logging-jvm", version.ref = "kotlin-logging" }
 java-jwt = { module = "com.auth0:java-jwt", version.ref = "java-jwt" }
+junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 fluent-assert-bom = { module = "me.ahoo.test:fluent-assert-bom", version.ref = "fluent-assert" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }


### PR DESCRIPTION
- Add JUnit BOM (Bill of Materials) to manage JUnit-related dependencies
- Include junit-platform-launcher as a testRuntimeOnly dependency
- Update gradle/libs.versions.toml to include JUnit 5.13.0 version
- Update build.gradle.kts to use the new JUnit BOM for test dependencies