### PR TITLE
documentation(skills): optimize CoApi skill publishing

### DIFF
--- a/skills/coapi-developer/SKILL.md
+++ b/skills/coapi-developer/SKILL.md
@@ -1,77 +1,54 @@
 ---
 name: coapi-developer
 description: >
-  Help developers use the CoApi library — a Spring Framework HTTP client auto-configuration library that supports
-  both reactive (WebClient) and synchronous (RestClient) programming models. Use this skill whenever the user mentions
-  CoApi, @CoApi, @HttpExchange, HTTP client interface, Spring HTTP Interface, or wants to create/modify/test HTTP client
-  proxies. Also trigger when users ask about Spring 6 HTTP Interface auto-configuration, load-balanced HTTP clients,
-  switching between reactive and sync HTTP client modes, or reference classes like CoApiFactoryBean, CoApiDefinition,
-  ClientMode, WebClientFactoryBean, RestClientFactoryBean, HttpExchangeAdapterFactory, AutoCoApiRegistrar,
-  or configuration properties like coapi.mode, coapi.clients, coapi.base-packages. Make sure to use this skill even
-  if the user doesn't explicitly mention CoApi by name but is working with Spring HTTP Interface proxies, declaring
-  annotated HTTP client interfaces, or configuring Spring Boot auto-configuration for HTTP exchanges.
+  Help developers use and maintain CoApi, a Spring HTTP Interface client auto-configuration library for typed
+  @HttpExchange proxies backed by reactive WebClient or synchronous RestClient. Use this skill when the user mentions
+  CoApi, @CoApi, @EnableCoApi, @LoadBalanced, @HttpExchange, Spring HTTP Interface clients, Spring Boot
+  auto-configuration for HTTP clients, reactive vs sync client mode, Spring Cloud LoadBalancer integration, or repository
+  classes such as CoApiDefinition, CoApiFactoryBean, AutoCoApiRegistrar, EnableCoApiRegistrar, ClientMode,
+  WebClientFactoryBean, RestClientFactoryBean, ReactiveHttpExchangeAdapterFactory, SyncHttpExchangeAdapterFactory,
+  or properties such as coapi.mode, coapi.base-packages, and coapi.clients.
 ---
 
 # CoApi Developer Skill
 
-You are helping a developer use the **CoApi** library (`me.ahoo.coapi`), which provides zero-boilerplate auto-configuration for Spring 6 HTTP Interface clients (`@HttpExchange`). It supports both reactive (`WebClient`) and synchronous (`RestClient`) modes, with optional client-side load balancing via Spring Cloud LoadBalancer.
+Use this skill to help with **CoApi** (`me.ahoo.coapi`), which turns Spring `@HttpExchange`
+interfaces into Spring beans with minimal setup. CoApi is Kotlin-first, supports Spring Boot 4.x /
+Spring Framework 7.x in the current codebase, and can create either reactive `WebClient` or
+synchronous `RestClient` proxies.
 
-CoApi targets Spring Boot 4.x / Spring Framework 7.x with Kotlin (JVM 17).
+## How To Work
 
-## How to Respond
+1. Identify the request type, then load only the needed reference file:
+   - New client interface, application config, load balancing, or examples: read [references/usage.md](references/usage.md).
+   - Architecture, module boundaries, annotations, mode selection, or implementation edits: read [references/concepts.md](references/concepts.md).
+   - Tests, assertions, `ApplicationContextRunner`, integration tests, or MockK: read [references/testing.md](references/testing.md).
+   - Startup failures, missing beans, client mode surprises, base URL issues, or load-balancer problems: read [references/troubleshooting.md](references/troubleshooting.md).
+2. Prefer concise, working Kotlin snippets unless the user asks for Java.
+3. Recommend the simplest CoApi-supported approach first, then name the tradeoff when another approach is valid.
+4. If the request is outside CoApi's purpose, say so directly and route the user to the Spring tool that owns it.
 
-- Generate working, copy-pasteable code snippets — not pseudocode
-- When multiple approaches exist, recommend the simplest one first and explain the tradeoffs
-- If the developer's request goes beyond what CoApi handles (e.g., retry logic, circuit breaking, WebSocket), say so clearly and suggest the right tool for that concern
+## Essential Facts
 
-## Quick Reference
+- Dependency: `implementation("me.ahoo.coapi:coapi-spring-boot-starter")`.
+- Main annotations:
+  - `@CoApi(baseUrl = "...", serviceId = "...", name = "...")` marks an interface as a CoApi client.
+  - `@LoadBalanced` explicitly enables load-balanced client wiring.
+  - `@EnableCoApi(clients = [...])` explicitly registers client interfaces.
+- Client mode: `coapi.mode` supports `AUTO`, `REACTIVE`, and `SYNC`.
+- Base URL resolution has two layers: `@CoApi(baseUrl)` wins over `serviceId` in the annotation definition, while `coapi.clients.<name>.base-url` overrides that definition at HTTP client factory time.
+- Load balancing requires `spring-cloud-starter-loadbalancer` plus the matching reactive filter or sync interceptor when explicitly configured.
+- Tests in this repository must use `me.ahoo.test.asserts.assert`; do not use AssertJ `assertThat`.
 
-**Maven coordinates:**
-```kotlin
-implementation("me.ahoo.coapi:coapi-spring-boot-starter")
-```
+## CoApi Boundaries
 
-Note: The Maven artifact ID is `coapi-spring-boot-starter` (not `spring-boot-starter`). The module name in the project is `spring-boot-starter`, but the published artifact follows the pattern `coapi-<module-name>` via `getArchivesName()`.
+CoApi is for declarative request-response HTTP clients built from typed Spring interfaces. It does not
+own WebSocket or SSE clients, resilience policies, arbitrary one-off HTTP calls, or non-Spring runtime
+wiring. For those concerns, use Spring `WebClient`, `RestClient`, `WebSocketClient`, filters,
+interceptors, or a resilience library such as Resilience4j.
 
-**Key annotations:**
-- `@CoApi(baseUrl | serviceId, name)` — marks an interface as an HTTP client proxy
-- `@LoadBalanced` — enables load balancing for the client
-- `@EnableCoApi(clients = [...])` — explicitly registers client interfaces (alternative to auto-scanning)
+## Minimal Client Pattern
 
-**Configuration property:** `coapi.mode` = `AUTO` | `REACTIVE` | `SYNC`
-
-## When NOT to Use CoApi
-
-CoApi is designed specifically for declarative HTTP Interface clients. It is not the right choice for:
-
-- **WebSocket or SSE clients** — CoApi only supports request-response HTTP. For streaming protocols, use `WebSocketClient` or `WebClient` directly.
-- **Fine-grained retry / circuit breaking** — CoApi delegates HTTP calls to `WebClient` or `RestClient`, so resilience features belong in filters/interceptors (e.g., Resilience4j). CoApi configures the wiring, not the resilience policy.
-- **Non-Spring applications** — CoApi relies on Spring Boot auto-configuration and bean registration. For standalone use, call Spring's `HttpServiceProxyFactory` directly.
-- **Arbitrary HTTP calls without an interface** — If you just need to make one-off HTTP requests, use `RestClient` or `WebClient` directly. CoApi adds value when you have a typed interface contract.
-
-## Creating @CoApi Interfaces
-
-### 1. Define the API interface
-
-Use standard Spring `@HttpExchange` annotations on the interface. A class-level `@HttpExchange` sets a base path for all methods — this is useful for grouping endpoints under a common prefix. Return types determine the programming model:
-- **Reactive**: `Flux<T>`, `Mono<T>`, or any `Publisher<T>`
-- **Sync**: plain Java/Kotlin types (`List<T>`, `T`, `void`)
-
-```kotlin
-@HttpExchange("todo")
-interface TodoApi {
-    @GetExchange
-    fun getTodo(): Flux<Todo>
-}
-
-data class Todo(val title: String)
-```
-
-### 2. Create the @CoApi client
-
-The `@CoApi` annotation goes on the client interface. There are several ways to specify the target:
-
-**Direct URL (with optional placeholder):**
 ```kotlin
 @CoApi(baseUrl = "\${github.url}")
 interface GitHubApiClient {
@@ -80,299 +57,9 @@ interface GitHubApiClient {
 }
 ```
 
-**Service ID (load-balanced):**
-When you set `serviceId`, CoApi automatically constructs an `lb://serviceId` URL. This tells Spring Cloud LoadBalancer to resolve the actual host from the service registry — you don't need to know the concrete URL at development time.
-```kotlin
-@CoApi(serviceId = "github-service")
-interface ServiceApiClient {
-    @GetExchange("repos/{owner}/{repo}/issues")
-    fun getIssue(@PathVariable owner: String, @PathVariable repo: String): Flux<Issue>
-}
-```
-
-**Load-balanced URL:**
-```kotlin
-@CoApi(baseUrl = "lb://order-service")
-interface OrderClient
-```
-
-**Load-balanced with @LoadBalanced annotation:**
-Use `@LoadBalanced` when you want to explicitly mark a client for load balancing regardless of the URL scheme — for example, when the base URL is a plain `https://` address that should still go through the load balancer.
-```kotlin
-@CoApi(baseUrl = "https://order-service")
-@LoadBalanced
-interface OrderClient {
-    @GetExchange("/orders/{id}")
-    fun getOrder(@PathVariable id: String): Order
-}
-
-data class Order(val id: String, val status: String)
-```
-
-Requires `spring-cloud-starter-loadbalancer` on classpath.
-
-**Extending a shared API interface:**
-This pattern is useful in microservice architectures where the API contract is defined in a shared module — the provider and consumer both depend on the same interface.
-```kotlin
-@CoApi(serviceId = "provider-service")
-interface TodoClient : TodoApi
-```
-
-**No base URL (resolved from config):**
-When no `baseUrl` or `serviceId` is set, the base URL must come from `coapi.clients.<name>.baseUrl` in application config. This is useful when the target URL varies per environment and should not be hardcoded in the annotation.
-```kotlin
-@CoApi
-interface ConfigResolvedClient {
-    @GetExchange("/users")
-    fun getUsers(): Flux<User>
-}
-```
-
-### 3. Resolve base URL
-
-Base URL resolution priority (first match wins):
-1. `@CoApi(baseUrl = "...")` — supports `${property}` placeholders resolved at startup
-2. `@CoApi(serviceId = "...")` — auto-constructs `lb://serviceId`
-3. `coapi.clients.<name>.baseUrl` in application config — runtime override per client
-
-Do not set both `baseUrl` and `serviceId` on the same `@CoApi` — the behavior is undefined.
-
-## Spring Boot Auto-Configuration
-
-Adding the starter dependency triggers auto-configuration of:
-- Classpath scanning for `@CoApi`-annotated interfaces
-- `WebClient` or `RestClient` bean creation per client
-- HTTP service proxy creation via `HttpServiceProxyFactory`
-
-### Client Mode
-
-Set via `coapi.mode` in `application.yml`:
-
 ```yaml
+github:
+  url: https://api.github.com
 coapi:
-  mode: AUTO  # AUTO | REACTIVE | SYNC
+  mode: AUTO
 ```
-
-- `AUTO` (default): detects reactive Web stack on classpath → uses `WebClient`; otherwise uses `RestClient`. The detection works by checking for `org.springframework.web.reactive.HandlerResult`, which is present whenever `spring-webflux` is on the classpath.
-- `REACTIVE`: forces `WebClient`-based adapters
-- `SYNC`: forces `RestClient`-based adapters
-
-### Scan Base Packages
-
-By default, scans the Spring Boot application's base package. Override with:
-
-```yaml
-coapi:
-  base-packages:
-    - com.example.clients
-    - com.other.api
-```
-
-### Per-Client Configuration
-
-Override individual client settings in `application.yml`:
-
-```yaml
-coapi:
-  clients:
-    GitHubApiClient:
-      base-url: https://api.github.com
-      load-balanced: false
-      reactive:
-        filter:
-          names:
-            - loadBalancerExchangeFilterFunction
-      sync:
-        interceptor:
-          names:
-            - loadBalancerInterceptor
-```
-
-### Explicit Registration
-
-If auto-scanning doesn't fit (e.g., client interfaces live in an external library JAR), use `@EnableCoApi` to list clients explicitly:
-
-```kotlin
-@EnableCoApi(
-    clients = [
-        GitHubApiClient::class,
-        ServiceApiClient::class,
-        TodoClient::class
-    ]
-)
-@SpringBootApplication
-class MyApp
-```
-
-### Load Balancing
-
-Requires `spring-cloud-starter-loadbalancer` on classpath:
-
-```kotlin
-implementation("org.springframework.cloud:spring-cloud-starter-loadbalancer")
-```
-
-Then configure filters/interceptors per client mode:
-
-**Reactive (WebClient):** Set filter by bean name or type in `coapi.clients.<name>.reactive.filter`
-**Sync (RestClient):** Set interceptor by bean name or type in `coapi.clients.<name>.sync.interceptor`
-
-## Writing Tests
-
-Tests use `me.ahoo.test:fluent-assert-core` for assertions — use the `.assert()` extension, not AssertJ's `assertThat()`. This provides null-safe, Kotlin-idiomatic assertions.
-
-```kotlin
-import me.ahoo.test.asserts.assert
-```
-
-### Unit Tests for CoApiDefinition
-
-Test annotation parsing with `MockEnvironment`:
-
-```kotlin
-class CoApiDefinitionTest {
-    @Test
-    fun toCoApiDefinitionIfServiceApi() {
-        val coApiDefinition = MockServiceApi::class.java.toCoApiDefinition(MockEnvironment())
-        coApiDefinition.loadBalanced.assert().isTrue()
-        coApiDefinition.baseUrl.assert().isEqualTo("http://order-service")
-    }
-}
-
-@CoApi(serviceId = "order-service")
-interface MockServiceApi
-```
-
-### Integration Tests with ApplicationContextRunner
-
-Use `ApplicationContextRunner` to test the full bean registration:
-
-```kotlin
-class CoApiContextTest {
-    @Test
-    fun `should create Reactive CoApi bean`() {
-        ApplicationContextRunner()
-            .withPropertyValues("github.url=https://api.github.com")
-            .withBean(WebClientBuilderCustomizer::class.java, { WebClientBuilderCustomizer.NoOp })
-            .withUserConfiguration(WebClientAutoConfiguration::class.java)
-            .withUserConfiguration(EnableCoApiConfiguration::class.java)
-            .run { context ->
-                context.assert()
-                    .hasSingleBean(ReactiveHttpExchangeAdapterFactory::class.java)
-                    .hasSingleBean(GitHubApiClient::class.java)
-            }
-    }
-}
-
-@EnableCoApi(clients = [GitHubApiClient::class])
-class EnableCoApiConfiguration
-```
-
-### Spring Boot Integration Tests
-
-```kotlin
-@SpringBootTest
-class ConsumerServerTest {
-    @Autowired
-    private lateinit var gitHubApiClient: GitHubApiClient
-
-    @Test
-    fun getIssueByGitHubApiClient() {
-        gitHubApiClient.getIssue("Ahoo-Wang", "Wow")
-            .doOnNext { println(it) }
-            .blockLast()
-    }
-}
-```
-
-### Testing with MockK
-
-Use MockK for mocking client interfaces:
-
-```kotlin
-@Test
-fun `should mock CoApi client`() {
-    val mockClient = mockk<GitHubApiClient>()
-    every { mockClient.getIssue("owner", "repo") } returns Flux.just(Issue("url"))
-    // ... test with mockClient
-}
-```
-
-## Common Patterns
-
-### Sync vs Reactive in the Same Interface
-
-A single interface can mix sync and reactive return types. CoApi's `HttpServiceProxyFactory` detects the return type per method and uses the appropriate adapter — you don't need separate interfaces for sync and reactive.
-
-```kotlin
-@CoApi(baseUrl = "\${github.url}")
-interface GitHubSyncClient {
-    @GetExchange("repos/{owner}/{repo}/issues")
-    fun getIssue(@PathVariable owner: String, @PathVariable repo: String): List<Issue>  // sync
-
-    @GetExchange("repos/{owner}/{repo}/issues")
-    fun getIssueWithReactive(@PathVariable owner: String, @PathVariable repo: String): Flux<Issue>  // reactive
-}
-```
-
-### Dynamic URI with UriBuilderFactory
-
-Pass `UriBuilderFactory` or `URI` directly for dynamic URL resolution — useful when the target host is determined at runtime:
-
-```kotlin
-@CoApi
-interface UriApiClient {
-    @GetExchange
-    fun getIssueByUri(uri: URI): Flux<Issue>
-
-    @GetExchange
-    fun getIssue(
-        uriBuilderFactory: UriBuilderFactory,
-        @PathVariable owner: String,
-        @PathVariable repo: String
-    ): Flux<Issue>
-}
-```
-
-## Troubleshooting
-
-### Client bean not found
-
-This typically manifests as `NoSuchBeanDefinitionException` at startup.
-
-- Check that `@CoApi` is on an **interface**, not a class — CoApi uses Java dynamic proxies, which only work with interfaces
-- Verify the interface is in a scanned package (or listed in `@EnableCoApi`)
-- Check `coapi.base-packages` if using custom packages
-
-### Load balancing not working
-
-Requests go to a single instance or fail with connection refused.
-
-- Ensure `spring-cloud-starter-loadbalancer` is on classpath
-- Verify `serviceId` is set (or `baseUrl` uses `lb://` prefix), or `@LoadBalanced` is on the interface
-- Configure the appropriate filter (reactive) or interceptor (sync) in `coapi.clients.<name>`
-
-### Wrong client mode
-
-The application uses `RestClient` when you expected `WebClient`, or vice versa.
-
-- Check `coapi.mode` property
-- `AUTO` mode: verify if `org.springframework.web.reactive.HandlerResult` is on classpath — it's present when `spring-webflux` is a dependency
-- Explicitly set `REACTIVE` or `SYNC` if auto-detection is wrong
-
-### Base URL not resolving
-
-Requests fail with "no base URL configured" or go to the wrong host.
-
-- Property placeholders (`${...}`) require the property to exist in `application.yml` — a missing property causes startup failure
-- `serviceId` auto-constructs `lb://serviceId` — don't also set `baseUrl`, the two are mutually exclusive
-- Per-client `coapi.clients.<name>.baseUrl` overrides annotation values
-- When no `baseUrl` or `serviceId` is set on `@CoApi`, the base URL must come from config
-
-## Key Implementation Details
-
-- `@CoApi` is meta-annotated with `@Component`, so interfaces are Spring beans and can be `@Autowired` directly
-- Bean names: `{name}.HttpClient` for the HTTP client, `{name}.CoApi` for the proxy
-- `CoApiFactoryBean` creates proxies via Spring's `HttpServiceProxyFactory`
-- `ClientMode.inferClientMode()` checks for reactive class on classpath when mode is `AUTO`
-- `AutoCoApiRegistrar` (boot) or `EnableCoApiRegistrar` handles classpath scanning and bean registration

--- a/skills/coapi-developer/SKILL.md
+++ b/skills/coapi-developer/SKILL.md
@@ -36,9 +36,9 @@ synchronous `RestClient` proxies.
   - `@LoadBalanced` explicitly enables load-balanced client wiring.
   - `@EnableCoApi(clients = [...])` explicitly registers client interfaces.
 - Client mode: `coapi.mode` supports `AUTO`, `REACTIVE`, and `SYNC`.
-- Base URL resolution has two layers: `@CoApi(baseUrl)` wins over `serviceId` in the annotation definition, while `coapi.clients.<name>.base-url` overrides that definition at HTTP client factory time.
+- Base URL resolution has two layers: `@CoApi(baseUrl)` wins over `serviceId`; `serviceId`/`lb://` targets are normalized to `http://...` with `loadBalanced=true`; `coapi.clients.<name>.base-url` can override the parsed definition at HTTP client factory time.
 - Load balancing requires `spring-cloud-starter-loadbalancer` plus the matching reactive filter or sync interceptor when explicitly configured.
-- Tests in this repository must use `me.ahoo.test.asserts.assert`; do not use AssertJ `assertThat`.
+- Prefer `me.ahoo.test.asserts.assert` for value assertions. For `ApplicationContextRunner` bean assertions, mirror existing tests with `AssertionsForInterfaceTypes.assertThat(context)`.
 
 ## CoApi Boundaries
 

--- a/skills/coapi-developer/agents/openai.yaml
+++ b/skills/coapi-developer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "CoApi Developer"
+  short_description: "Build Spring HTTP Interface clients"
+  default_prompt: "Use $coapi-developer to build a typed Spring HTTP Interface client with CoApi."

--- a/skills/coapi-developer/evals/evals.json
+++ b/skills/coapi-developer/evals/evals.json
@@ -18,6 +18,18 @@
       "prompt": "I'm writing tests for my CoApi client that calls an external weather API. I want to use ApplicationContextRunner to verify the client bean is registered correctly, and also write a Spring Boot integration test that actually calls the API. Show me both test patterns using the project's testing conventions (fluent-assert, JUnit 5).",
       "expected_output": "Two test classes: one using ApplicationContextRunner for unit-level bean verification, one using @SpringBootTest for integration testing. Both should follow the project's conventions with fluent-assert (.assert()) and proper test structure.",
       "files": []
+    },
+    {
+      "id": 4,
+      "prompt": "My CoApi client interface is annotated with @CoApi, but Spring fails at startup with NoSuchBeanDefinitionException for that interface. Give me a focused troubleshooting checklist.",
+      "expected_output": "A checklist that verifies the target is an interface, the interface is annotated or registered through @EnableCoApi, scanning or coapi.base-packages covers the package, the starter dependency is present, and external JAR clients are registered explicitly.",
+      "files": []
+    },
+    {
+      "id": 5,
+      "prompt": "Explain CoApi base URL precedence when @CoApi(baseUrl), @CoApi(serviceId), and coapi.clients.<name>.base-url are involved.",
+      "expected_output": "An explanation that separates annotation definition resolution from HTTP client factory resolution: @CoApi(baseUrl) wins over serviceId inside CoApiDefinition, serviceId becomes lb://<serviceId> when baseUrl is blank, and coapi.clients.<name>.base-url overrides the parsed definition when the HTTP client factory builds the client.",
+      "files": []
     }
   ]
 }

--- a/skills/coapi-developer/evals/evals.json
+++ b/skills/coapi-developer/evals/evals.json
@@ -28,7 +28,7 @@
     {
       "id": 5,
       "prompt": "Explain CoApi base URL precedence when @CoApi(baseUrl), @CoApi(serviceId), and coapi.clients.<name>.base-url are involved.",
-      "expected_output": "An explanation that separates annotation definition resolution from HTTP client factory resolution: @CoApi(baseUrl) wins over serviceId inside CoApiDefinition, serviceId becomes lb://<serviceId> when baseUrl is blank, and coapi.clients.<name>.base-url overrides the parsed definition when the HTTP client factory builds the client.",
+      "expected_output": "An explanation that separates annotation definition resolution from HTTP client factory resolution: @CoApi(baseUrl) wins over serviceId inside CoApiDefinition, serviceId is first resolved through lb://<serviceId> and then normalized to http://<serviceId> with loadBalanced=true, and coapi.clients.<name>.base-url overrides the parsed definition when the HTTP client factory builds the client.",
       "files": []
     }
   ]

--- a/skills/coapi-developer/references/concepts.md
+++ b/skills/coapi-developer/references/concepts.md
@@ -44,7 +44,7 @@ targets.
 Key annotation fields:
 
 - `baseUrl`: Direct base URL, including property placeholders such as `${github.url}`.
-- `serviceId`: Service discovery ID. CoApi constructs `lb://<serviceId>`.
+- `serviceId`: Service discovery ID. CoApi first resolves it through the load-balanced URL path, then stores a normalized `http://<serviceId>` base URL with `loadBalanced=true`.
 - `name`: Optional logical client name for bean names and per-client configuration.
 
 Avoid setting both `baseUrl` and `serviceId` on the same client. Prefer `serviceId` for service
@@ -55,7 +55,8 @@ discovery and `baseUrl` for fixed external endpoints.
 CoApi resolves the target URL in two layers:
 
 1. `CoApiDefinition` resolves annotation data. `@CoApi(baseUrl = "...")` wins first; if it is blank,
-   `@CoApi(serviceId = "...")` becomes `lb://<serviceId>`; otherwise the definition URL is blank.
+   `@CoApi(serviceId = "...")` is resolved through `lb://<serviceId>`. `toCoApiDefinition()` then
+   normalizes `lb://...` to `http://...` and sets `loadBalanced=true`; otherwise the definition URL is blank.
 2. `AbstractHttpClientFactoryBean.getBaseUrl()` checks `coapi.clients.<name>.base-url` first. If that
    property is blank, it falls back to `CoApiDefinition.baseUrl`.
 
@@ -75,7 +76,8 @@ Use explicit mode when classpath inference is surprising or when tests need dete
 ## Load Balancing
 
 Load balancing is activated when the client uses `serviceId`, an `lb://` base URL, or explicit
-`@LoadBalanced`.
+`@LoadBalanced`. The parsed `CoApiDefinition.baseUrl` passed to client factories uses an `http://...`
+URL; load-balancer behavior comes from `loadBalanced=true` plus the matching filter or interceptor.
 
 Requirements:
 

--- a/skills/coapi-developer/references/concepts.md
+++ b/skills/coapi-developer/references/concepts.md
@@ -1,0 +1,111 @@
+# CoApi Concepts
+
+Load this reference when explaining CoApi architecture, choosing a configuration model, or editing the
+CoApi repository itself.
+
+## Contents
+
+- [Domain Model](#domain-model)
+- [Modules](#modules)
+- [Client Definition](#client-definition)
+- [Base URL Resolution](#base-url-resolution)
+- [Client Mode](#client-mode)
+- [Load Balancing](#load-balancing)
+- [Bean And Factory Shape](#bean-and-factory-shape)
+- [Scope Boundaries](#scope-boundaries)
+
+## Domain Model
+
+CoApi provides Spring Boot auto-configuration for Spring HTTP Interface clients. Users declare
+interfaces with Spring `@HttpExchange` methods, mark client interfaces with `@CoApi`, and inject the
+generated proxy as a Spring bean.
+
+Current repository assumptions:
+
+- Kotlin/JVM 17.
+- Spring Boot 4.x and Spring Framework 7.x in the current mainline.
+- Published artifacts use `me.ahoo.coapi:*`.
+- The starter artifact is `me.ahoo.coapi:coapi-spring-boot-starter`.
+
+## Modules
+
+| Module | Responsibility |
+| --- | --- |
+| `api` | Public annotations such as `@CoApi` and `@LoadBalanced`. Public API changes require care. |
+| `spring` | Core registrar, definition parsing, factory beans, and reactive/sync client SPI. |
+| `spring-boot-starter` | Auto-configuration and `CoApiProperties`. |
+| `example/*` | Provider/consumer examples for shared API contracts and client usage. |
+
+## Client Definition
+
+`@CoApi` belongs on an interface. CoApi relies on Java dynamic proxies, so classes are not valid client
+targets.
+
+Key annotation fields:
+
+- `baseUrl`: Direct base URL, including property placeholders such as `${github.url}`.
+- `serviceId`: Service discovery ID. CoApi constructs `lb://<serviceId>`.
+- `name`: Optional logical client name for bean names and per-client configuration.
+
+Avoid setting both `baseUrl` and `serviceId` on the same client. Prefer `serviceId` for service
+discovery and `baseUrl` for fixed external endpoints.
+
+## Base URL Resolution
+
+CoApi resolves the target URL in two layers:
+
+1. `CoApiDefinition` resolves annotation data. `@CoApi(baseUrl = "...")` wins first; if it is blank,
+   `@CoApi(serviceId = "...")` becomes `lb://<serviceId>`; otherwise the definition URL is blank.
+2. `AbstractHttpClientFactoryBean.getBaseUrl()` checks `coapi.clients.<name>.base-url` first. If that
+   property is blank, it falls back to `CoApiDefinition.baseUrl`.
+
+Use this carefully when explaining precedence: per-client configuration can override the annotation at
+factory time, but it does not change the parsed `CoApiDefinition`.
+
+## Client Mode
+
+`coapi.mode` selects the HTTP stack:
+
+- `AUTO`: infer from the classpath. Reactive web classes lead to `WebClient`; otherwise CoApi uses `RestClient`.
+- `REACTIVE`: force `WebClient`.
+- `SYNC`: force `RestClient`.
+
+Use explicit mode when classpath inference is surprising or when tests need deterministic wiring.
+
+## Load Balancing
+
+Load balancing is activated when the client uses `serviceId`, an `lb://` base URL, or explicit
+`@LoadBalanced`.
+
+Requirements:
+
+- Add `org.springframework.cloud:spring-cloud-starter-loadbalancer`.
+- Reactive clients use a `WebClient` filter such as `loadBalancerExchangeFilterFunction`.
+- Sync clients use a `RestClient` interceptor such as `loadBalancerInterceptor`.
+
+## Bean And Factory Shape
+
+Useful repository names:
+
+- `CoApiDefinition`: parsed annotation and configuration data.
+- `CoApiFactoryBean`: creates the HTTP interface proxy.
+- `WebClientFactoryBean`: creates reactive HTTP clients.
+- `RestClientFactoryBean`: creates synchronous HTTP clients.
+- `ReactiveHttpExchangeAdapterFactory` and `SyncHttpExchangeAdapterFactory`: create Spring HTTP exchange adapters.
+- `AutoCoApiRegistrar` and `EnableCoApiRegistrar`: discover and register client beans.
+- `ClientMode`: mode selection and classpath inference.
+
+Bean naming conventions are usually `{name}.HttpClient` for the backing HTTP client and `{name}.CoApi`
+for the proxy.
+
+## Scope Boundaries
+
+CoApi wires typed request-response clients. It does not own:
+
+- WebSocket or SSE clients.
+- Retry, circuit breaker, rate limiting, or timeout policy beyond what filters/interceptors configure.
+- One-off HTTP calls that do not benefit from a typed interface.
+- Non-Spring application wiring.
+
+For those cases, recommend direct Spring `WebClient`, `RestClient`, `WebSocketClient`, filters,
+interceptors, or Resilience4j.

--- a/skills/coapi-developer/references/testing.md
+++ b/skills/coapi-developer/references/testing.md
@@ -17,8 +17,8 @@ Spring Boot auto-configuration.
 
 - Test framework: JUnit 5.
 - Mocking: MockK.
-- Assertions: `me.ahoo.test.asserts.assert`.
-- Do not use AssertJ `assertThat`.
+- Prefer `me.ahoo.test.asserts.assert` for value assertions.
+- For `ApplicationContextRunner` bean assertions, follow existing tests with `AssertionsForInterfaceTypes.assertThat(context)`.
 - Useful commands:
   - `./gradlew :spring:test`
   - `./gradlew :spring-boot-starter:test`
@@ -28,6 +28,7 @@ Import:
 
 ```kotlin
 import me.ahoo.test.asserts.assert
+import org.assertj.core.api.AssertionsForInterfaceTypes
 ```
 
 ## Definition Parsing Unit Test
@@ -52,21 +53,35 @@ interface MockServiceApi
 ## HTTP Client Factory Precedence Test
 
 When testing final base URL selection, assert that per-client configuration wins over the parsed
-definition URL.
+definition URL. Include the local factory and definition helpers from
+`spring/src/test/kotlin/me/ahoo/coapi/spring/client/IHttpClientFactoryBeanTest.kt`.
 
 ```kotlin
-@Test
-fun `getBaseUrl should return URL from properties when available`() {
-    val mockApplicationContext = mockk<ApplicationContext>()
-    val mockClientProperties = mockk<ClientProperties>()
+private val mockDefinition = CoApiDefinition(
+    name = "testClient",
+    apiType = Any::class.java,
+    baseUrl = "http://localhost:8080",
+    loadBalanced = false
+)
 
-    every { mockApplicationContext.getBean(ClientProperties::class.java) } returns mockClientProperties
-    every { mockClientProperties.getBaseUri("testClient") } returns "http://properties-url:9090"
+private class TestHttpClientFactoryBean(
+    override val definition: CoApiDefinition
+) : AbstractHttpClientFactoryBean()
 
-    val factoryBean = TestHttpClientFactoryBean(mockDefinition)
-    factoryBean.setApplicationContext(mockApplicationContext)
+class IHttpClientFactoryBeanTest {
+    @Test
+    fun `getBaseUrl should return URL from properties when available`() {
+        val mockApplicationContext = mockk<ApplicationContext>()
+        val mockClientProperties = mockk<ClientProperties>()
 
-    factoryBean.getBaseUrl().assert().isEqualTo("http://properties-url:9090")
+        every { mockApplicationContext.getBean(ClientProperties::class.java) } returns mockClientProperties
+        every { mockClientProperties.getBaseUri("testClient") } returns "http://properties-url:9090"
+
+        val factoryBean = TestHttpClientFactoryBean(mockDefinition)
+        factoryBean.setApplicationContext(mockApplicationContext)
+
+        factoryBean.getBaseUrl().assert().isEqualTo("http://properties-url:9090")
+    }
 }
 ```
 
@@ -84,7 +99,7 @@ class CoApiContextTest {
             .withUserConfiguration(WebClientAutoConfiguration::class.java)
             .withUserConfiguration(EnableCoApiConfiguration::class.java)
             .run { context ->
-                context.assert()
+                AssertionsForInterfaceTypes.assertThat(context)
                     .hasSingleBean(ReactiveHttpExchangeAdapterFactory::class.java)
                     .hasSingleBean(GitHubApiClient::class.java)
             }

--- a/skills/coapi-developer/references/testing.md
+++ b/skills/coapi-developer/references/testing.md
@@ -1,0 +1,142 @@
+# CoApi Testing
+
+Load this reference when writing or reviewing tests for CoApi clients, registrars, factory beans, or
+Spring Boot auto-configuration.
+
+## Contents
+
+- [Repository Conventions](#repository-conventions)
+- [Definition Parsing Unit Test](#definition-parsing-unit-test)
+- [HTTP Client Factory Precedence Test](#http-client-factory-precedence-test)
+- [ApplicationContextRunner Test](#applicationcontextrunner-test)
+- [Spring Boot Integration Test](#spring-boot-integration-test)
+- [MockK Client Test](#mockk-client-test)
+- [Coverage Checklist](#coverage-checklist)
+
+## Repository Conventions
+
+- Test framework: JUnit 5.
+- Mocking: MockK.
+- Assertions: `me.ahoo.test.asserts.assert`.
+- Do not use AssertJ `assertThat`.
+- Useful commands:
+  - `./gradlew :spring:test`
+  - `./gradlew :spring-boot-starter:test`
+  - `./gradlew :spring:test --tests "me.ahoo.coapi.spring.CoApiDefinitionTest"`
+
+Import:
+
+```kotlin
+import me.ahoo.test.asserts.assert
+```
+
+## Definition Parsing Unit Test
+
+Use `MockEnvironment` for annotation and property resolution.
+
+```kotlin
+class CoApiDefinitionTest {
+    @Test
+    fun toCoApiDefinitionIfServiceApi() {
+        val coApiDefinition = MockServiceApi::class.java.toCoApiDefinition(MockEnvironment())
+
+        coApiDefinition.loadBalanced.assert().isTrue()
+        coApiDefinition.baseUrl.assert().isEqualTo("http://order-service")
+    }
+}
+
+@CoApi(serviceId = "order-service")
+interface MockServiceApi
+```
+
+## HTTP Client Factory Precedence Test
+
+When testing final base URL selection, assert that per-client configuration wins over the parsed
+definition URL.
+
+```kotlin
+@Test
+fun `getBaseUrl should return URL from properties when available`() {
+    val mockApplicationContext = mockk<ApplicationContext>()
+    val mockClientProperties = mockk<ClientProperties>()
+
+    every { mockApplicationContext.getBean(ClientProperties::class.java) } returns mockClientProperties
+    every { mockClientProperties.getBaseUri("testClient") } returns "http://properties-url:9090"
+
+    val factoryBean = TestHttpClientFactoryBean(mockDefinition)
+    factoryBean.setApplicationContext(mockApplicationContext)
+
+    factoryBean.getBaseUrl().assert().isEqualTo("http://properties-url:9090")
+}
+```
+
+## ApplicationContextRunner Test
+
+Use `ApplicationContextRunner` for auto-configuration and bean registration assertions.
+
+```kotlin
+class CoApiContextTest {
+    @Test
+    fun `should create reactive CoApi bean`() {
+        ApplicationContextRunner()
+            .withPropertyValues("github.url=https://api.github.com")
+            .withBean(WebClientBuilderCustomizer::class.java, { WebClientBuilderCustomizer.NoOp })
+            .withUserConfiguration(WebClientAutoConfiguration::class.java)
+            .withUserConfiguration(EnableCoApiConfiguration::class.java)
+            .run { context ->
+                context.assert()
+                    .hasSingleBean(ReactiveHttpExchangeAdapterFactory::class.java)
+                    .hasSingleBean(GitHubApiClient::class.java)
+            }
+    }
+}
+
+@EnableCoApi(clients = [GitHubApiClient::class])
+class EnableCoApiConfiguration
+```
+
+## Spring Boot Integration Test
+
+Use this style when the test should start the application context and exercise a real client bean.
+
+```kotlin
+@SpringBootTest
+class ConsumerServerTest {
+    @Autowired
+    private lateinit var gitHubApiClient: GitHubApiClient
+
+    @Test
+    fun getIssueByGitHubApiClient() {
+        gitHubApiClient.getIssue("Ahoo-Wang", "CoApi")
+            .doOnNext { println(it) }
+            .blockLast()
+    }
+}
+```
+
+## MockK Client Test
+
+Mock generated client interfaces directly when the unit under test only depends on the contract.
+
+```kotlin
+@Test
+fun `should mock CoApi client`() {
+    val mockClient = mockk<GitHubApiClient>()
+    every { mockClient.getIssue("owner", "repo") } returns Flux.just(Issue("url"))
+
+    mockClient.getIssue("owner", "repo")
+        .blockFirst()
+        .assert()
+        .isEqualTo(Issue("url"))
+}
+```
+
+## Coverage Checklist
+
+For behavior changes, cover the smallest relevant layer:
+
+- Annotation parsing or property precedence: unit test around `CoApiDefinition`.
+- Registrar behavior: `ApplicationContextRunner`.
+- Reactive vs sync mode selection: focused tests for `ClientMode` or adapter factory registration.
+- Starter auto-configuration: `spring-boot-starter` tests.
+- Example behavior: example module tests only when the public workflow changes.

--- a/skills/coapi-developer/references/troubleshooting.md
+++ b/skills/coapi-developer/references/troubleshooting.md
@@ -1,0 +1,72 @@
+# CoApi Troubleshooting
+
+Load this reference when diagnosing startup failures, missing clients, wrong HTTP stack selection, load
+balancing issues, or base URL resolution problems.
+
+## Contents
+
+- [Client Bean Not Found](#client-bean-not-found)
+- [Load Balancing Not Working](#load-balancing-not-working)
+- [Wrong Client Mode](#wrong-client-mode)
+- [Base URL Not Resolving](#base-url-not-resolving)
+- [Unsupported Concern](#unsupported-concern)
+
+## Client Bean Not Found
+
+Typical symptom: `NoSuchBeanDefinitionException` for a CoApi client interface.
+
+Check:
+
+1. The target is an interface, not a class.
+2. The interface has `@CoApi` or is explicitly registered through `@EnableCoApi`.
+3. The package is covered by component scanning or `coapi.base-packages`.
+4. The application imports the starter dependency, not only the annotation API.
+5. If the client lives in another JAR, use `@EnableCoApi(clients = [...])`.
+
+## Load Balancing Not Working
+
+Typical symptoms: direct host calls, unresolved service names, or connection refused.
+
+Check:
+
+1. `org.springframework.cloud:spring-cloud-starter-loadbalancer` is on the classpath.
+2. The client uses `serviceId`, an `lb://` base URL, or `@LoadBalanced`.
+3. Reactive mode has a load-balancer `WebClient` filter available.
+4. Sync mode has a load-balancer `RestClient` interceptor available.
+5. Per-client filter/interceptor names match actual Spring bean names.
+
+## Wrong Client Mode
+
+Typical symptom: CoApi creates `RestClient` when the user expected `WebClient`, or the reverse.
+
+Check:
+
+1. `coapi.mode` is not forcing the unexpected mode.
+2. `AUTO` mode sees the expected classpath. Reactive web classes cause reactive mode inference.
+3. Tests set mode explicitly when both reactive and sync dependencies are present.
+4. The method return type is compatible with the selected adapter.
+
+Prefer explicit `REACTIVE` or `SYNC` for deterministic tests and production deployments that should not
+change behavior when dependencies move.
+
+## Base URL Not Resolving
+
+Typical symptoms: startup failure, unresolved placeholders, or requests going to the wrong target.
+
+Check:
+
+1. Placeholder properties such as `${github.url}` exist in the active environment.
+2. The client does not set both `baseUrl` and `serviceId`.
+3. `serviceId` is expected to become `lb://<serviceId>`.
+4. `coapi.clients.<name>.base-url` uses the correct client name and may override the annotation URL.
+5. Empty `@CoApi` clients have an external `base-url` configured.
+
+## Unsupported Concern
+
+If the user asks for streaming protocols, retries, circuit breakers, or one-off HTTP calls, explain the
+boundary:
+
+- WebSocket/SSE: use Spring `WebSocketClient` or `WebClient` streaming directly.
+- Retry/circuit breaker: use filters/interceptors plus Resilience4j or a similar library.
+- One-off calls: use `WebClient` or `RestClient` directly.
+- Non-Spring runtime: use Spring `HttpServiceProxyFactory` manually or another HTTP client.

--- a/skills/coapi-developer/references/troubleshooting.md
+++ b/skills/coapi-developer/references/troubleshooting.md
@@ -57,7 +57,7 @@ Check:
 
 1. Placeholder properties such as `${github.url}` exist in the active environment.
 2. The client does not set both `baseUrl` and `serviceId`.
-3. `serviceId` is expected to become `lb://<serviceId>`.
+3. `serviceId` and `lb://...` targets are expected to appear as `http://...` in the parsed base URL, with `loadBalanced=true`.
 4. `coapi.clients.<name>.base-url` uses the correct client name and may override the annotation URL.
 5. Empty `@CoApi` clients have an external `base-url` configured.
 

--- a/skills/coapi-developer/references/usage.md
+++ b/skills/coapi-developer/references/usage.md
@@ -1,0 +1,219 @@
+# CoApi Usage Patterns
+
+Load this reference when creating client interfaces, dependency snippets, application configuration, or
+load-balanced examples.
+
+## Contents
+
+- [Dependency](#dependency)
+- [Define The API Contract](#define-the-api-contract)
+- [Direct URL Client](#direct-url-client)
+- [Service Discovery Client](#service-discovery-client)
+- [Load-Balanced URL Or Annotation](#load-balanced-url-or-annotation)
+- [Shared Provider And Consumer Contract](#shared-provider-and-consumer-contract)
+- [Config-Resolved Client](#config-resolved-client)
+- [Client Mode](#client-mode)
+- [Per-Client Base URL Override](#per-client-base-url-override)
+- [Per-Client Load-Balancer Wiring](#per-client-load-balancer-wiring)
+- [Explicit Registration](#explicit-registration)
+- [Dynamic URI](#dynamic-uri)
+
+## Dependency
+
+```kotlin
+implementation("me.ahoo.coapi:coapi-spring-boot-starter")
+```
+
+Use the published artifact `coapi-spring-boot-starter`; the repository module is named
+`spring-boot-starter`, but artifacts are published with the `coapi-` prefix.
+
+## Define The API Contract
+
+Use Spring `@HttpExchange` annotations on the interface. Return types guide the programming model:
+
+- Reactive: `Flux<T>`, `Mono<T>`, or another `Publisher<T>`.
+- Sync: plain JVM values such as `T`, `List<T>`, or `Unit`/`void`.
+
+```kotlin
+@HttpExchange("todo")
+interface TodoApi {
+    @GetExchange
+    fun getTodo(): Flux<Todo>
+}
+
+data class Todo(val title: String)
+```
+
+## Direct URL Client
+
+```kotlin
+@CoApi(baseUrl = "\${github.url}")
+interface GitHubApiClient {
+    @GetExchange("repos/{owner}/{repo}/issues")
+    fun getIssue(@PathVariable owner: String, @PathVariable repo: String): Flux<Issue>
+}
+
+data class Issue(val url: String)
+```
+
+```yaml
+github:
+  url: https://api.github.com
+```
+
+## Service Discovery Client
+
+Use `serviceId` when the target is registered with service discovery. CoApi builds `lb://<serviceId>`.
+
+```kotlin
+@CoApi(serviceId = "user-service")
+interface UserClient {
+    @GetExchange("/users/{id}")
+    fun getUser(@PathVariable id: String): Mono<User>
+
+    @GetExchange("/users")
+    fun listUsers(): Flux<User>
+}
+
+data class User(val id: String, val name: String)
+```
+
+Add load-balancer support:
+
+```kotlin
+implementation("org.springframework.cloud:spring-cloud-starter-loadbalancer")
+```
+
+## Load-Balanced URL Or Annotation
+
+Use an `lb://` URL when the service name belongs in configuration-like annotation data:
+
+```kotlin
+@CoApi(baseUrl = "lb://order-service")
+interface OrderClient
+```
+
+Use `@LoadBalanced` when the annotation should explicitly request load-balanced wiring:
+
+```kotlin
+@CoApi(baseUrl = "https://order-service")
+@LoadBalanced
+interface OrderClient {
+    @GetExchange("/orders/{id}")
+    fun getOrder(@PathVariable id: String): Order
+}
+```
+
+## Shared Provider And Consumer Contract
+
+Put the shared API interface in a common module, implement it on the provider, and extend it on the
+consumer client.
+
+```kotlin
+@HttpExchange("todo")
+interface TodoApi {
+    @GetExchange
+    fun getTodo(): Flux<Todo>
+}
+
+@CoApi(serviceId = "provider-service")
+interface TodoClient : TodoApi
+
+@RestController
+class TodoController : TodoApi {
+    override fun getTodo(): Flux<Todo> =
+        Flux.range(1, 10).map { Todo("todo-$it") }
+}
+```
+
+## Config-Resolved Client
+
+When no URL belongs in source code, leave `@CoApi` empty and configure the named client externally.
+
+```kotlin
+@CoApi
+interface ConfigResolvedClient {
+    @GetExchange("/users")
+    fun getUsers(): Flux<User>
+}
+```
+
+```yaml
+coapi:
+  clients:
+    ConfigResolvedClient:
+      base-url: https://api.example.com
+```
+
+## Client Mode
+
+```yaml
+coapi:
+  mode: AUTO # AUTO | REACTIVE | SYNC
+```
+
+Use `REACTIVE` for `WebClient`, `SYNC` for `RestClient`, and `AUTO` when classpath inference is
+acceptable.
+
+## Per-Client Base URL Override
+
+`coapi.clients.<name>.base-url` overrides the URL derived from `@CoApi(baseUrl)` or `serviceId` when
+the HTTP client factory builds the backing client.
+
+```yaml
+coapi:
+  clients:
+    GitHubApiClient:
+      base-url: https://api.github.com
+```
+
+## Per-Client Load-Balancer Wiring
+
+```yaml
+coapi:
+  clients:
+    UserClient:
+      reactive:
+        filter:
+          names:
+            - loadBalancerExchangeFilterFunction
+      sync:
+        interceptor:
+          names:
+            - loadBalancerInterceptor
+```
+
+## Explicit Registration
+
+Use `@EnableCoApi` when auto-scanning does not cover the client package.
+
+```kotlin
+@EnableCoApi(
+    clients = [
+        GitHubApiClient::class,
+        UserClient::class,
+        TodoClient::class
+    ]
+)
+@SpringBootApplication
+class ConsumerApplication
+```
+
+## Dynamic URI
+
+Accept `URI` or `UriBuilderFactory` in the interface method when the target is fully dynamic.
+
+```kotlin
+@CoApi
+interface UriApiClient {
+    @GetExchange
+    fun getIssueByUri(uri: URI): Flux<Issue>
+
+    @GetExchange
+    fun getIssue(
+        uriBuilderFactory: UriBuilderFactory,
+        @PathVariable owner: String,
+        @PathVariable repo: String
+    ): Flux<Issue>
+}
+```

--- a/skills/coapi-developer/references/usage.md
+++ b/skills/coapi-developer/references/usage.md
@@ -63,7 +63,9 @@ github:
 
 ## Service Discovery Client
 
-Use `serviceId` when the target is registered with service discovery. CoApi builds `lb://<serviceId>`.
+Use `serviceId` when the target is registered with service discovery. CoApi routes it through the
+load-balanced URL path, then the backing `WebClient` or `RestClient` receives a normalized
+`http://<serviceId>` base URL with `loadBalanced=true`.
 
 ```kotlin
 @CoApi(serviceId = "user-service")
@@ -86,7 +88,8 @@ implementation("org.springframework.cloud:spring-cloud-starter-loadbalancer")
 
 ## Load-Balanced URL Or Annotation
 
-Use an `lb://` URL when the service name belongs in configuration-like annotation data:
+Use an `lb://` URL when the service name belongs in configuration-like annotation data. During
+definition parsing, CoApi normalizes it to `http://<serviceId>` and marks the client load-balanced:
 
 ```kotlin
 @CoApi(baseUrl = "lb://order-service")
@@ -157,8 +160,8 @@ acceptable.
 
 ## Per-Client Base URL Override
 
-`coapi.clients.<name>.base-url` overrides the URL derived from `@CoApi(baseUrl)` or `serviceId` when
-the HTTP client factory builds the backing client.
+`coapi.clients.<name>.base-url` overrides the normalized URL derived from `@CoApi(baseUrl)`,
+`serviceId`, or `lb://...` when the HTTP client factory builds the backing client.
 
 ```yaml
 coapi:

--- a/skills/plugins.json
+++ b/skills/plugins.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "plugins": [
+    {
+      "name": "ahoo-coapi-skills",
+      "description": "CoApi skills for building and testing Spring HTTP Interface client proxies with reactive WebClient, synchronous RestClient, and Spring Cloud LoadBalancer support.",
+      "skills": {
+        "include": [
+          "*"
+        ],
+        "exclude": [
+          "*-workspace"
+        ]
+      },
+      "keywords": [
+        "coapi",
+        "spring",
+        "http-interface",
+        "webclient",
+        "restclient",
+        "load-balancer",
+        "reactive",
+        "kotlin"
+      ],
+      "category": "development",
+      "interface": {
+        "displayName": "Ahoo CoApi Skills",
+        "capabilities": [
+          "Skills"
+        ],
+        "defaultPrompt": "Help me build and test CoApi Spring HTTP Interface clients with reactive or synchronous mode."
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Refactor the CoApi developer skill into a compact entrypoint with progressive references for concepts, usage, testing, and troubleshooting.
- Add OpenAI-facing skill interface metadata in `agents/openai.yaml`.
- Add `skills/plugins.json` as neutral source metadata for publishing `ahoo-coapi-skills` while excluding workspace skills.
- Expand skill eval coverage for missing-bean troubleshooting and CoApi base URL precedence.

## Impact

This keeps the skill easier to trigger and lighter to load, while preserving detailed CoApi guidance behind reference files. The publishing metadata lets the upstream skills marketplace aggregate the CoApi skill without generating product-specific manifests in this repository.

## Validation

- `PYTHONPATH=/tmp/coapi-skill-validate-pyyaml python3 /Users/ahoo/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/coapi-developer`
- `jq -e . skills/plugins.json`
- `jq -e . skills/coapi-developer/evals/evals.json`
- `PYTHONPATH=/tmp/coapi-skill-validate-pyyaml python3 - <<PY ... PY` for `agents/openai.yaml`
- `find skills -maxdepth 3 \( -name .codex-plugin -o -name .claude-plugin -o -name marketplace.json -o -path skills/plugins/* \) -print`
- `git diff --cached --check`