### PR TITLE
ci(renovate): ignore coapi-developer-workspace from dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
   "commitMessagePrefix": "fix(deps)",
   "commitMessageTopic": "{{depName}}",
   "rangeStrategy": "bump",
+  "ignorePaths": ["coapi-developer-workspace/"],
   "lockFileMaintenance": { "enabled": false },
   "prConcurrentLimit": 5,
   "packageRules": [


### PR DESCRIPTION
## 背景

PR #217 (`fix(deps) Update spring`) 的描述里宣称了一批 Spring Cloud / BOM 更新（`2023.0.2→2023.0.6`、`2025.0.0→2025.1.2`、boot `3.3.0→3.5.16` 等），但这些版本并不在 `gradle/libs.versions.toml` 里，而是散落在 `coapi-developer-workspace/` 目录下。

## 问题

`coapi-developer-workspace/` 存放的是 **冻结的 eval/benchmark 快照**（`outputs/` 目录旁就是 `grading.json`、`timing.json`、`benchmark.json`、`review.html`），代表编码评测在某时间点产出的录制结果，并非真实依赖。Renovate 却深入该目录去 bump 其中硬编码的版本号，造成：

1. PR 描述与实际改动不符（描述是按旧 base 自动生成的）
2. 误改了本应冻结的评测产物

## 修复

在 `renovate.json` 增加：

```json
"ignorePaths": ["coapi-developer-workspace/"]
```

[`ignorePaths` 是可合并选项](https://docs.renovatebot.com/configuration-options/)，会追加到 `config:recommended` 的默认值（`node_modules/`、`bower_components/`、`vendor/`、test 目录），不会覆盖它们。

## 效果

后续 Renovate 的依赖升级 PR（如 spring、kotlin 分组）将只动 `gradle/libs.versions.toml`，不再误碰 eval 快照。

## 关联

- 根因追溯自 #217 的冲突修复
- 在 #217 已回复 Copilot 评审意见说明此方案